### PR TITLE
Configuration can now take a previous configuration and use it as preset-values

### DIFF
--- a/README
+++ b/README
@@ -191,6 +191,26 @@ SAMPLES
     "forty-two"
     42.0
 
+  <========< samples/f.rb >========>
+
+  ~ > cat samples/f.rb
+
+    #
+    # configuration.rb let's you inherit values from another configuration.
+    # Like this, you keep your code very dry.
+    #
+
+      require 'configuration'
+
+      Configuration.load 'f'
+
+      p c.a
+      p c.b
+
+  ~ > ruby samples/f.rb
+
+    10
+    2
 
 
 AUTHOR

--- a/config/f.rb
+++ b/config/f.rb
@@ -1,0 +1,12 @@
+default = Configuration.for( 'default' ) {
+
+  a 1
+  b 2
+
+}
+
+Configuration.for( 'f', default ) {
+
+  a 10
+  
+}

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -16,6 +16,8 @@ class Configuration
   module ClassMethods
     def for name, options = nil, &block
       name = name.to_s
+      options = options.to_hash if options.is_a?( Configuration )
+
       if Table.has_key?(name)
         if options or block
           configuration = Table[name]
@@ -132,8 +134,10 @@ class Configuration
 
     def self.evaluate configuration, options = {}, &block
       dsl = new configuration
-      Pure[dsl].instance_eval(&block) if block
+      
       options.each{|key, value| Pure[dsl].send key, value}
+      Pure[dsl].instance_eval(&block) if block
+
       Pure[dsl].instance_eval{ @__configuration }
     end
 

--- a/samples/f.rb
+++ b/samples/f.rb
@@ -1,0 +1,11 @@
+#
+# configuration.rb let's you inherit values from another configuration.
+# Like this, you keep your code very dry.
+#
+
+  require 'configuration'
+
+  c = Configuration.for 'f'
+
+  p c.a
+  p c.b


### PR DESCRIPTION
Hi,

I've added support for taking a previous configuration as default values for a new one, like so:
default = COnfiguration.for( 'default' ) {
  secret 'default secret'
  foo 'bar'
}

config = COnfiguration.for( 'config', default ) {
  secret 'very secret'
}

p config.secret     #=> 'very secret'
p config.              #=> 'bar'

The block values take precedence over the given defaults (which can still be just a hash).

It would be great if you could merge this into your gem.

Thanks and best,
Rudi
