### PR TITLE
failing test for overwritten object_id

### DIFF
--- a/test/overwrite_test.rb
+++ b/test/overwrite_test.rb
@@ -1,0 +1,29 @@
+require 'minitest/autorun'
+require 'configuration.rb'
+
+describe Configuration do
+
+  before do
+    # similar to config/sample d.rb
+    Configuration.for('d'){
+      built_in_object_id Send('object_id')
+      object_id 42
+      built_in_inspect Send('inspect')
+      inspect 'forty-two'
+      p 42.0
+    }
+
+    @c = Configuration.for 'd'
+  end
+
+  it "must overwrite built-in methods" do
+    @c.object_id.must_equal 42
+    @c.object_id.wont_equal @c.built_in_object_id
+
+    @c.inspect.must_equal 'forty-two'
+    @c.inspect.wont_equal @c.built_in_inspect
+
+    @c.p.must_equal 42.0
+  end
+
+end


### PR DESCRIPTION
I made this simple test because I couldn't get your examples to work.  It is failing only with `object_id`, `p` and `inspect` work correctly. Any ideas about why? I'm using:

```
ruby 1.9.3p194 (2012-04-20 revision 35410) [x86_64-linux]
```

and

```
configuration (1.3.1)
```

Also, I don't get the same output from d.rb in the REAMDE (it looks kinda wrong..). Maybe I misunderstood that :P
